### PR TITLE
Changed string comparison to Equals with StringComparer

### DIFF
--- a/MimeTypeMap.List/MimeTypeMap.cs
+++ b/MimeTypeMap.List/MimeTypeMap.cs
@@ -56,7 +56,7 @@ namespace MimeTypeMap.List
                 throw new ArgumentException($"Requested mime type is not valid: {mimeType}", nameof(mimeType));
             }
 
-            return Mappings.Value.Where(s => s.Value.Contains(mimeType.ToLower())).Select(s => s.Key);
+            return Mappings.Value.Where(s => s.Value.Contains(mimeType, StringComparer.OrdinalIgnoreCase)).Select(s => s.Key);
         }
     }
 }


### PR DESCRIPTION
Fixes #5 

The issue said Equals with StringComparison.OrdinalIgnoreCase but for the Contains it is ofcourse different, it's StringComparer.OrdinalIgnoreCase as a second parameter to the Contains function.
The dictionary itself is already case insensitive for the key, but this is comparing on the values...

Regards,

Sandro Mastronardi